### PR TITLE
ES1 and ES2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,41 @@
 # ansible-elasticsearch_dev
 
-This will install elasticsearch and its head plugin.
+By default, this will install elasticsearch and its head plugin. There are a number
+of options to configure the ES installation.
 
-I wouldn't recommend using this for a production system! For one, it only
-installs elasticsearch and it doesn't try to form a cluster.
-
-
-```
-roles:
-- EDITD.elasticsearch_dev
-```
-
-Optionally a version can be specified.
+It only installs elasticsearch on a single host and it doesn't try to form a cluster.
 
 ```
 roles:
 - EDITD.elasticsearch_dev
-  elasticsearch_version: 1.7.4
+```
+
+The default ES version to install is `2.3.0`. To override, use
+
+```
+elasticsearch_version: 2.3.0
+```
+
+By default, no ES config is written - it can be set by using
+
+```
+elasticsearch_config_file: path/to/es/config
+```
+
+The path should be relative to the playbook directory.
+
+When running ES on a Vagrant machine, it needs to listen on all interface to be
+accessible from outside the vagrant box. This is added to the config by default,
+but can be stopped by setting
+
+```
+elasticsearch_listen_on_all_interfaces: false
+```
+
+Finally, the head plugin is installed by default - to override this, you can use
+
+```
+plugins_to_install: ["mobz/elasticsearch-head", "some_other_ES_plugin"]
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,6 @@ elasticsearch_version: 2.3.0
 elasticsearch_file_name: elasticsearch-{{ elasticsearch_version }}.deb
 elasticsearch_base_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
 elasticsearch_config_file: false
+elasticsearch_listen_on_all_interfaces: true
 
 plugins_to_install: ["mobz/elasticsearch-head"]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,8 @@
 ---
 
-elasticsearch_version: 1.7.4
+elasticsearch_version: 2.3.0
+elasticsearch_file_name: elasticsearch-{{ elasticsearch_version }}.deb
+elasticsearch_base_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
+elasticsearch_config_file: false
+
+plugins_to_install: ["mobz/elasticsearch-head"]

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -1,0 +1,9 @@
+def get_major_version(filename):
+    return int(filename[14])
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'get_major_version': get_major_version,
+        }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,9 +21,9 @@
   when: not elasticsearch_installed.stat.exists
 
 - name: Install ES plugins
-  shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}remove {{ item }} && /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
-  when: head_plugin_path.stat.exists != true
+  shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
   with_items: "{{ plugins_to_install }}"
+  ignore_errors: True
 
 - name: write Elasticsearch config
   copy: src={{ elasticsearch_config_file }} dest=/etc/elasticsearch/elasticsearch.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,43 +3,39 @@
 - name: install ES dependencies
   apt: pkg={{ item }} state=present update_cache=true cache_valid_time=3600
   with_items: [openjdk-7-jre-headless]
-  sudo: yes
-
-- name: Check if ES has already been installed
-  stat: path=/etc/elasticsearch-installed
-  register: elasticsearch_installed
 
 - name: Check if we've already downloaded the DEB
-  stat: path=/tmp/elasticsearch-{{ elasticsearch_version }}.deb
+  stat: path=/tmp/{{ elasticsearch_file_name }}
   register: elasticsearch_downloaded
 
 - name: Download ES deb
-  get_url: url=https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-{{ elasticsearch_version }}.deb dest=/tmp/elasticsearch-{{ elasticsearch_version }}.deb
-  sudo: yes
-  when: elasticsearch_installed.stat.exists != true and elasticsearch_downloaded.stat.exists != true
+  get_url: url={{ elasticsearch_base_url }}/{{ elasticsearch_file_name }} dest=/tmp/{{ elasticsearch_file_name }}
+  when: elasticsearch_downloaded.stat.exists != true
 
-- name: Install ES deb
-  command: dpkg -i /tmp/elasticsearch-{{ elasticsearch_version }}.deb
-  sudo: yes
-  when: elasticsearch_installed.stat.exists != true
-
-- name: Mark ES as installed
-  file: path=/etc/elasticsearch-installed state=touch
-  sudo: yes
-  when: elasticsearch_installed.stat.exists != true
+- name: Install elasticsearch
+  apt: deb=/tmp/{{ elasticsearch_file_name }} state=present force=yes
 
 - name: Check if head plugin path exists
   stat: path=/usr/share/elasticsearch/plugins/head
   register: head_plugin_path
 
 - name: Install ES head plugin
-  command: /usr/share/elasticsearch/bin/plugin --install mobz/elasticsearch-head
-  sudo: yes
+  shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
   when: head_plugin_path.stat.exists != true
+  with_items: "{{ plugins_to_install }}"
 
-- name: Start ES
+- name: write Elasticsearch config
+  copy: src={{ elasticsearch_config_file }} dest=/etc/elasticsearch/elasticsearch.yml
+  when: elasticsearch_config_file != false
+
+- name: Make ES listen on all interfaces
+  lineinfile: 'dest=/etc/elasticsearch/elasticsearch.yml line="network.host: 0.0.0.0" regexp=^network.host'
+
+- name: Restart ES
   service: >
     name=elasticsearch
-    state=started
+    state=restarted
     enabled=yes
-  sudo: yes
+
+- name: wait for Elasticsearch to actually be ready
+  wait_for: host=127.0.0.1 port=9200 delay=5 timeout=60

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   stat: path=/usr/share/elasticsearch/plugins/head
   register: head_plugin_path
 
-- name: Install ES head plugin
+- name: Install ES plugins
   shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
   when: head_plugin_path.stat.exists != true
   with_items: "{{ plugins_to_install }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Download ES deb
   get_url: url={{ elasticsearch_base_url }}/{{ elasticsearch_file_name }} dest=/tmp/{{ elasticsearch_file_name }}
-  when: not elasticsearch_downloaded.stat.exists
+  when: not elasticsearch_downloaded.stat.exists and not elasticsearch_installed.stat.exists
 
 - name: Install elasticsearch
   apt: deb=/tmp/{{ elasticsearch_file_name }} state=present force=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
 
 - name: Make ES listen on all interfaces
   lineinfile: 'dest=/etc/elasticsearch/elasticsearch.yml line="network.host: 0.0.0.0" regexp=^network.host'
+  when: ansible_product_name == "VirtualBox"
 
 - name: Restart ES
   service: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,8 @@
 - name: Install ES plugins
   shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
   with_items: "{{ plugins_to_install }}"
-  ignore_errors: True
+  register: plugin_response
+  failed_when: "'ERROR' in plugin_response.stdout and 'already exists' not in plugin_response.stdout"
 
 - name: write Elasticsearch config
   copy: src={{ elasticsearch_config_file }} dest=/etc/elasticsearch/elasticsearch.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   register: head_plugin_path
 
 - name: Install ES plugins
-  shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
+  shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}remove {{ item }} && /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
   when: head_plugin_path.stat.exists != true
   with_items: "{{ plugins_to_install }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Make ES listen on all interfaces
   lineinfile: 'dest=/etc/elasticsearch/elasticsearch.yml line="network.host: 0.0.0.0" regexp=^network.host'
-  when: ansible_product_name == "VirtualBox"
+  when: elasticsearch_listen_on_all_interfaces
 
 - name: Restart ES
   service: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: write Elasticsearch config
   copy: src={{ elasticsearch_config_file }} dest=/etc/elasticsearch/elasticsearch.yml
-  when: elasticsearch_config_file
+  when: elasticsearch_config_file != false
 
 - name: Make ES listen on all interfaces
   lineinfile: 'dest=/etc/elasticsearch/elasticsearch.yml line="network.host: 0.0.0.0" regexp=^network.host'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,10 +20,6 @@
   apt: deb=/tmp/{{ elasticsearch_file_name }} state=present force=yes
   when: not elasticsearch_installed.stat.exists
 
-- name: Check if head plugin path exists
-  stat: path=/usr/share/elasticsearch/plugins/head
-  register: head_plugin_path
-
 - name: Install ES plugins
   shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}remove {{ item }} && /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
   when: head_plugin_path.stat.exists != true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,17 @@
   stat: path=/tmp/{{ elasticsearch_file_name }}
   register: elasticsearch_downloaded
 
+- name: Check if we've already installed elasticsearch
+  stat: path=/usr/share/elasticsearch/lib/elasticsearch-{{ elasticsearch_version }}.jar
+  register: elasticsearch_installed
+
 - name: Download ES deb
   get_url: url={{ elasticsearch_base_url }}/{{ elasticsearch_file_name }} dest=/tmp/{{ elasticsearch_file_name }}
   when: not elasticsearch_downloaded.stat.exists
 
 - name: Install elasticsearch
   apt: deb=/tmp/{{ elasticsearch_file_name }} state=present force=yes
+  when: not elasticsearch_installed.stat.exists
 
 - name: Check if head plugin path exists
   stat: path=/usr/share/elasticsearch/plugins/head

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Download ES deb
   get_url: url={{ elasticsearch_base_url }}/{{ elasticsearch_file_name }} dest=/tmp/{{ elasticsearch_file_name }}
-  when: elasticsearch_downloaded.stat.exists != true
+  when: not elasticsearch_downloaded.stat.exists
 
 - name: Install elasticsearch
   apt: deb=/tmp/{{ elasticsearch_file_name }} state=present force=yes
@@ -26,7 +26,7 @@
 
 - name: write Elasticsearch config
   copy: src={{ elasticsearch_config_file }} dest=/etc/elasticsearch/elasticsearch.yml
-  when: elasticsearch_config_file != false
+  when: elasticsearch_config_file
 
 - name: Make ES listen on all interfaces
   lineinfile: 'dest=/etc/elasticsearch/elasticsearch.yml line="network.host: 0.0.0.0" regexp=^network.host'


### PR DESCRIPTION
@EDITD/hackers - This adds support for installing ES1 and ES2.

It install head plugin by default, but others can be specified. To keep support for ansible 1.x and 2.x, I'm not doing any `sudo`, or `become`, but the role expects that it has sudo privileges.

I have tested this in a playbook, with:

``` yaml
  - role: EDITD.elasticsearch_dev
    when: not production_mode
    become: yes
    become_method: sudo
    elasticsearch_version: 2.3.0
    elasticsearch_config_file: files/elasticsearch.dev.yml
```

Closes https://github.com/EDITD/ansible-elasticsearch_dev/issues/1
