### PR TITLE
Es 5 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,6 @@
 
 elasticsearch_version: 2.3.0
 elasticsearch_file_name: elasticsearch-{{ elasticsearch_version }}.deb
-elasticsearch_base_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
 elasticsearch_config_file: false
 elasticsearch_listen_on_all_interfaces: true
 

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -2,8 +2,15 @@ def get_major_version(filename):
     return int(filename[14])
 
 
+def get_elasticsearch_base_url(version):
+    if version < 5:
+        return 'https://download.elasticsearch.org/elasticsearch/elasticsearch'
+    return 'https://artifacts.elastic.co/downloads/elasticsearch'
+
+
 class FilterModule(object):
     def filters(self):
         return {
             'get_major_version': get_major_version,
+            'get_elasticsearch_base_url': get_elasticsearch_base_url,
         }

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -8,9 +8,16 @@ def get_elasticsearch_base_url(version):
     return 'https://artifacts.elastic.co/downloads/elasticsearch'
 
 
+def get_openjdk_version(ubuntu_version):
+    if ubuntu_version == '14.04':
+        return 7
+    return 8
+
+
 class FilterModule(object):
     def filters(self):
         return {
             'get_major_version': get_major_version,
             'get_elasticsearch_base_url': get_elasticsearch_base_url,
+            'get_openjdk_version': get_openjdk_version,
         }

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -8,16 +8,9 @@ def get_elasticsearch_base_url(version):
     return 'https://artifacts.elastic.co/downloads/elasticsearch'
 
 
-def get_openjdk_version(ubuntu_version):
-    if ubuntu_version == '14.04':
-        return 7
-    return 8
-
-
 class FilterModule(object):
     def filters(self):
         return {
             'get_major_version': get_major_version,
             'get_elasticsearch_base_url': get_elasticsearch_base_url,
-            'get_openjdk_version': get_openjdk_version,
         }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
   shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
   with_items: "{{ plugins_to_install }}"
   register: plugin_response
+  when: elasticsearch_file_name|get_major_version < 5
   failed_when: "'ERROR' in plugin_response.stdout and 'already exists' not in plugin_response.stdout"
 
 - name: write Elasticsearch config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   register: elasticsearch_installed
 
 - name: Download ES deb
-  get_url: url={{ elasticsearch_base_url }}/{{ elasticsearch_file_name }} dest=/tmp/{{ elasticsearch_file_name }}
+  get_url: url={{ elasticsearch_file_name|get_major_version|get_elasticsearch_base_url }}/{{ elasticsearch_file_name }} dest=/tmp/{{ elasticsearch_file_name }}
   when: not elasticsearch_downloaded.stat.exists and not elasticsearch_installed.stat.exists
 
 - name: Install elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: install ES dependencies
-  apt: pkg=openjdk-{{ ansible_distribution_version|get_openjdk_version }}-jre-headless state=present update_cache=true cache_valid_time=3600
+  apt: pkg={{ item }} state=present update_cache=true cache_valid_time=3600
+  with_items: [default-jre-headless]
 
 - name: Check if we've already downloaded the DEB
   stat: path=/tmp/{{ elasticsearch_file_name }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 
 - name: install ES dependencies
-  apt: pkg={{ item }} state=present update_cache=true cache_valid_time=3600
-  with_items: [openjdk-7-jre-headless]
+  apt: pkg=openjdk-{{ ansible_distribution_version|get_openjdk_version }}-jre-headless state=present update_cache=true cache_valid_time=3600
 
 - name: Check if we've already downloaded the DEB
   stat: path=/tmp/{{ elasticsearch_file_name }}


### PR DESCRIPTION
@EDITD/hackers - This updates the ES role for ES v5.

The only differences it needs to know about are the different url for downloading the deb, and not installing plugins.

There is also a change here that handles support for the openjdk version difference between Ubuntu 14.04 and 16.04!