### PR TITLE
Add ES mapper size plugin that we need to match our products mappings

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -8,9 +8,19 @@ def get_elasticsearch_base_url(version):
     return 'https://artifacts.elastic.co/downloads/elasticsearch'
 
 
+def get_elasticsearch_plugin_install_command(version):
+    if version == 1:
+        return '/usr/share/elasticsearch/bin/plugin --install'
+    elif version == 2:
+        return '/usr/share/elasticsearch/bin/plugin install'
+    else:
+        return '/usr/share/elasticsearch/bin/elasticsearch-plugin install'
+
+
 class FilterModule(object):
     def filters(self):
         return {
             'get_major_version': get_major_version,
             'get_elasticsearch_base_url': get_elasticsearch_base_url,
+            'plugin_install_command': get_elasticsearch_plugin_install_command,
         }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,16 +21,10 @@
   when: not elasticsearch_installed.stat.exists
 
 - name: Install ES plugins
-  shell: /usr/share/elasticsearch/bin/plugin {% if elasticsearch_file_name|get_major_version == 1 %}--{% endif %}install {{ item }}
+  shell: "{{ elasticsearch_file_name|get_major_version|plugin_install_command }} {{ item }}"
   with_items: "{{ plugins_to_install }}"
   register: plugin_response
-  when: elasticsearch_file_name|get_major_version < 5
   failed_when: "'ERROR' in plugin_response.stdout and 'already exists' not in plugin_response.stdout"
-
-- name: Install mapper-size plugin on ES5
-  shell: /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-size
-  become: yes
-  when: elasticsearch_file_name|get_major_version == 5
 
 - name: write Elasticsearch config
   copy: src={{ elasticsearch_config_file }} dest=/etc/elasticsearch/elasticsearch.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,11 @@
   when: elasticsearch_file_name|get_major_version < 5
   failed_when: "'ERROR' in plugin_response.stdout and 'already exists' not in plugin_response.stdout"
 
+- name: Install mapper-size plugin on ES5
+  shell: /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-size
+  become: yes
+  when: elasticsearch_file_name|get_major_version == 5
+
 - name: write Elasticsearch config
   copy: src={{ elasticsearch_config_file }} dest=/etc/elasticsearch/elasticsearch.yml
   when: elasticsearch_config_file != false


### PR DESCRIPTION
This adds the mapper size plugin for any local ES5 instances. 

We need it because we have a `_size` mapping in our mappings, which fails if the plugin isn't there. There's no disadvantage to having the plugin, so I thought it would be easiest to just install it without having to pass any vars down.