### PR TITLE
Reinstall plugins

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -8,13 +8,25 @@ def get_elasticsearch_base_url(version):
     return 'https://artifacts.elastic.co/downloads/elasticsearch'
 
 
-def get_elasticsearch_plugin_install_command(version):
+def get_elasticsearch_generic_command(version, command):
     if version == 1:
-        return '/usr/share/elasticsearch/bin/plugin --install'
+        return '/usr/share/elasticsearch/bin/plugin --{}'.format(command)
     elif version == 2:
-        return '/usr/share/elasticsearch/bin/plugin install'
+        return '/usr/share/elasticsearch/bin/plugin {}'.format(command)
     else:
-        return '/usr/share/elasticsearch/bin/elasticsearch-plugin install'
+        return '/usr/share/elasticsearch/bin/elasticsearch-plugin {}'.format(command)
+
+
+def get_elasticsearch_plugin_list_command(version):
+    return get_elasticsearch_generic_command(version, 'list')
+
+
+def get_elasticsearch_plugin_remove_command(version):
+    return get_elasticsearch_generic_command(version, 'remove')
+
+
+def get_elasticsearch_plugin_install_command(version):
+    return get_elasticsearch_generic_command(version, 'install')
 
 
 class FilterModule(object):
@@ -23,4 +35,5 @@ class FilterModule(object):
             'get_major_version': get_major_version,
             'get_elasticsearch_base_url': get_elasticsearch_base_url,
             'plugin_install_command': get_elasticsearch_plugin_install_command,
+            'plugin_remove_command': get_elasticsearch_plugin_remove_command,
         }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,17 @@
   apt: deb=/tmp/{{ elasticsearch_file_name }} state=present force=yes
   when: not elasticsearch_installed.stat.exists
 
-- name: Install ES plugins
+- name: Check which plugins are installed
+  shell: {{ elasticsearch_file_name|get_major_version|plugin_list_command}}
+  register: plugins
+  when: elasticsearch_file_name|get_major_version >= 5
+
+- name: Uninstall plugins
+  shell: {{ elasticsearch_file_name|get_major_version|plugin_remove_command }} {{ item }}
+  with_items: "{{ elasticsearch_plugins_to_install }}"
+  when: elasticsearch_plugins_to_install is defined and item in plugins.stdout_lines
+
+- name: Install plugins
   shell: "{{ elasticsearch_file_name|get_major_version|plugin_install_command }} {{ item }}"
   with_items: "{{ elasticsearch_plugins_to_install }}"
   register: plugin_response


### PR DESCRIPTION
This reinstalls plugins by default in the ES role, so things like `mapper-size`, which has specific versioning requirements, won't break an ES upgrade