### PR TITLE
Remove head plugin default and add mapper size

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,4 @@ elasticsearch_file_name: elasticsearch-{{ elasticsearch_version }}.deb
 elasticsearch_config_file: false
 elasticsearch_listen_on_all_interfaces: true
 
-elasticsearch_plugins_to_install: ["mobz/elasticsearch-head"]
+elasticsearch_plugins_to_install: ["mapper-size"]


### PR DESCRIPTION
Head no longer works in 6... This might affect some deploys though if the version isn't pinned.